### PR TITLE
Sync GitHub issues

### DIFF
--- a/lib/datapimp/cli/support/data_sync.rb
+++ b/lib/datapimp/cli/support/data_sync.rb
@@ -27,7 +27,28 @@ module Datapimp::DataSync
     repo = args.shift
     raise 'Must supply a repository name' if repo.empty?
 
-    issues = client.issues(repo)
+    issues = client.issues(repo, filter: "all")
+
+    if options.output
+      Pathname(options.output).open("w+") do |fh|
+        fh.write(issues)
+      end
+    else
+      puts issues.inspect
+    end
+  end
+
+  def self.sync_github_issue_comments(options, args)
+    client = Datapimp::Sync.github.api
+    raise 'Must setup github client' unless client
+
+    repo = args.shift
+    raise 'Must supply a repository name' if repo.empty?
+
+    issue = args.shift
+    raise 'Must supply an issue ID' if issue.empty?
+
+    issues = client.issue_comments(repo, issue)
 
     if options.output
       Pathname(options.output).open("w+") do |fh|

--- a/lib/datapimp/cli/support/data_sync.rb
+++ b/lib/datapimp/cli/support/data_sync.rb
@@ -19,4 +19,22 @@ module Datapimp::DataSync
       puts spreadsheet.to_s
     end
   end
+
+  def self.sync_github_issues(options, args)
+    client = Datapimp::Sync.github.api
+    raise 'Must setup github client' unless client
+
+    repo = args.shift
+    raise 'Must supply a repository name' if repo.empty?
+
+    issues = client.issues(repo)
+
+    if options.output
+      Pathname(options.output).open("w+") do |fh|
+        fh.write(issues)
+      end
+    else
+      puts issues.inspect
+    end
+  end
 end

--- a/lib/datapimp/cli/support/data_sync.rb
+++ b/lib/datapimp/cli/support/data_sync.rb
@@ -20,42 +20,38 @@ module Datapimp::DataSync
     end
   end
 
-  def self.sync_github_issues(options, args)
-    client = Datapimp::Sync.github.api
-    raise 'Must setup github client' unless client
+  class Github
+    attr_reader :options, :repository
 
-    repo = args.shift
-    raise 'Must supply a repository name' if repo.empty?
-
-    issues = client.issues(repo, filter: "all")
-
-    if options.output
-      Pathname(options.output).open("w+") do |fh|
-        fh.write(issues)
-      end
-    else
-      puts issues.inspect
+    def initialize(repository, options)
+      @repository = repository
+      @options    = options
     end
-  end
 
-  def self.sync_github_issue_comments(options, args)
-    client = Datapimp::Sync.github.api
-    raise 'Must setup github client' unless client
+    def sync_issues
+      issues = client.issues(repository, filter: "all")
+      serve_output(issues)
+    end
 
-    repo = args.shift
-    raise 'Must supply a repository name' if repo.empty?
+    def sync_issue_comments(issue_id)
+      comments = client.issue_comments(repository, issue_id)
+      serve_output(comments)
+    end
 
-    issue = args.shift
-    raise 'Must supply an issue ID' if issue.empty?
+    private
 
-    issues = client.issue_comments(repo, issue)
+    def client
+      @_client ||= Datapimp::Sync.github.api
+    end
 
-    if options.output
-      Pathname(options.output).open("w+") do |fh|
-        fh.write(issues)
+    def serve_output(output)
+      if @options.output
+        Pathname(options.output).open("w+") do |f|
+          f.write(output)
+        end
+      else
+        puts output.inspect
       end
-    else
-      puts issues.inspect
     end
   end
 end

--- a/lib/datapimp/cli/sync.rb
+++ b/lib/datapimp/cli/sync.rb
@@ -31,8 +31,10 @@ command "sync data" do |c|
   c.action do |args, options|
     if options.type == "google-spreadsheet" || options.type == "google"
       Datapimp::DataSync.sync_google_spreadsheet(options, args)
-    elsif options.type == "github-issues" || options.type == "github"
+    elsif options.type == "github-issues"
       Datapimp::DataSync.sync_github_issues(options, args)
+    elsif options.type == "github-issue-comments"
+      Datapimp::DataSync.sync_github_issue_comments(options, args)
     end
   end
 end

--- a/lib/datapimp/cli/sync.rb
+++ b/lib/datapimp/cli/sync.rb
@@ -31,6 +31,8 @@ command "sync data" do |c|
   c.action do |args, options|
     if options.type == "google-spreadsheet" || options.type == "google"
       Datapimp::DataSync.sync_google_spreadsheet(options, args)
+    elsif options.type == "github-issues" || options.type == "github"
+      Datapimp::DataSync.sync_github_issues(options, args)
     end
   end
 end

--- a/lib/datapimp/cli/sync.rb
+++ b/lib/datapimp/cli/sync.rb
@@ -32,9 +32,16 @@ command "sync data" do |c|
     if options.type == "google-spreadsheet" || options.type == "google"
       Datapimp::DataSync.sync_google_spreadsheet(options, args)
     elsif options.type == "github-issues"
-      Datapimp::DataSync.sync_github_issues(options, args)
+      repository  = args.shift
+
+      service = Datapimp::DataSync::Github.new(repository, options)
+      service.sync_issues
     elsif options.type == "github-issue-comments"
-      Datapimp::DataSync.sync_github_issue_comments(options, args)
+      repository  = args.shift
+      issue       = args.shift
+
+      service = Datapimp::DataSync::Github.new(repository, options)
+      service.sync_issue_comments(issue)
     end
   end
 end

--- a/lib/datapimp/clients/github.rb
+++ b/lib/datapimp/clients/github.rb
@@ -30,7 +30,7 @@ module Datapimp
 
       def api
         @api ||= begin
-                   Octokit::Client.new(access_token: Datapimp.config.github_access_token)
+                   Octokit::Client.new(access_token: Datapimp.config.github_access_token, auto_paginate: true)
                  end
       end
 


### PR DESCRIPTION
You can sync issues like this:
datapimp sync data 'architects/githubfs-test' --type github-issues

and sync comments like this:
datapimp sync data 'architects/githubfs-test' 1 --type github-issue-comments

No tests for this yet :(